### PR TITLE
jsdocs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "husky": "^4.3.0",
         "jest": "^26.4.2",
         "lint-staged": "^10.5.1",
-        "mongoose": "^6.0.8",
+        "mongoose": "^6.1.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.4.1",
         "typescript": "^4.1.3"
@@ -2796,9 +2796,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
-      "integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
+      "integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
       "dev": true,
       "dependencies": {
         "buffer": "^5.6.0"
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -8835,54 +8835,75 @@
       "dev": true
     },
     "node_modules/mongodb": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.1.tgz",
-      "integrity": "sha512-fbACrWEyvr6yl0sSiCGV0sqEiBwTtDJ8iSojmkDjAfw9JnOZSAkUyv9seFSPYhPPKwxp1PDtyjvBNfMDz0WBLQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.2.1.tgz",
+      "integrity": "sha512-nDC+ulM/Ea3Q2VG5eemuGfB7T4ORwrtKegH2XW9OLlUBgQF6OTNrzFCS1Z3SJGVA+T0Sr1xBYV6DMnp0A7us0g==",
       "dev": true,
       "dependencies": {
-        "bson": "^4.5.1",
-        "denque": "^1.5.0",
-        "mongodb-connection-string-url": "^2.0.0"
+        "bson": "^4.6.0",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.2.0"
       },
       "engines": {
         "node": ">=12.9.0"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "saslprep": "^1.0.3"
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
-      "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
+      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
       "dev": true,
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^9.1.0"
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
-      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/mongoose": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.8.tgz",
-      "integrity": "sha512-7XZ5TUoDtF8af7+mKfL58s8dN2BKmldQPTlmkb41PaRAleBVGeAck7Mj6JlIh9SOCi+64GT+afebiJaeyXe1Lw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.1.1.tgz",
+      "integrity": "sha512-9IODOeFDxW0hzvGmE2Yvy/TaFGLIXQWgE/L1D/x3lKVo8PGyokklgnvX0/Qia7lxiZvxe6+na1aA7v0gT+TN+g==",
       "dev": true,
       "dependencies": {
         "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "4.1.1",
+        "mongodb": "4.2.1",
         "mpath": "0.8.4",
         "mquery": "4.0.0",
         "ms": "2.1.2",
@@ -14026,9 +14047,9 @@
       }
     },
     "bson": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
-      "integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
+      "integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0"
@@ -14648,9 +14669,9 @@
       "dev": true
     },
     "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
       "dev": true
     },
     "detect-indent": {
@@ -18719,48 +18740,63 @@
       "dev": true
     },
     "mongodb": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.1.tgz",
-      "integrity": "sha512-fbACrWEyvr6yl0sSiCGV0sqEiBwTtDJ8iSojmkDjAfw9JnOZSAkUyv9seFSPYhPPKwxp1PDtyjvBNfMDz0WBLQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.2.1.tgz",
+      "integrity": "sha512-nDC+ulM/Ea3Q2VG5eemuGfB7T4ORwrtKegH2XW9OLlUBgQF6OTNrzFCS1Z3SJGVA+T0Sr1xBYV6DMnp0A7us0g==",
       "dev": true,
       "requires": {
-        "bson": "^4.5.1",
-        "denque": "^1.5.0",
-        "mongodb-connection-string-url": "^2.0.0",
-        "saslprep": "^1.0.0"
+        "bson": "^4.6.0",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.2.0",
+        "saslprep": "^1.0.3"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
-      "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
+      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
       "dev": true,
       "requires": {
         "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^9.1.0"
+        "whatwg-url": "^11.0.0"
       },
       "dependencies": {
-        "whatwg-url": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
-          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "dev": true,
           "requires": {
-            "tr46": "^2.1.0",
-            "webidl-conversions": "^6.1.0"
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "dev": true,
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
           }
         }
       }
     },
     "mongoose": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.8.tgz",
-      "integrity": "sha512-7XZ5TUoDtF8af7+mKfL58s8dN2BKmldQPTlmkb41PaRAleBVGeAck7Mj6JlIh9SOCi+64GT+afebiJaeyXe1Lw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.1.1.tgz",
+      "integrity": "sha512-9IODOeFDxW0hzvGmE2Yvy/TaFGLIXQWgE/L1D/x3lKVo8PGyokklgnvX0/Qia7lxiZvxe6+na1aA7v0gT+TN+g==",
       "dev": true,
       "requires": {
         "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "4.1.1",
+        "mongodb": "4.2.1",
         "mpath": "0.8.4",
         "mquery": "4.0.0",
         "ms": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongoose-tsgen",
-  "version": "8.4.6",
+  "version": "8.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongoose-tsgen",
-      "version": "8.4.6",
+      "version": "8.4.7",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-tsgen",
   "description": "A Typescript interface generator for Mongoose that works out of the box.",
-  "version": "8.4.6",
+  "version": "8.4.7",
   "author": "Francesco Virga @francescov1",
   "bin": {
     "mtgen": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "lint-staged": "^10.5.1",
-    "mongoose": "^6.0.8",
+    "mongoose": "^6.1.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.1",
     "typescript": "^4.1.3"

--- a/src/helpers/generator.ts
+++ b/src/helpers/generator.ts
@@ -4,6 +4,14 @@ import * as parser from "./parser";
 import * as templates from "./templates";
 import { ModelTypes } from "../types";
 
+// this strips comments of special tokens since ts-morph generates jsdoc tokens automatically
+const cleanComment = (comment: string) => {
+  return comment
+    .replace(/^\/\*\*[^\S\r\n]?/, "")
+    .replace(/[^\S\r\n]+\*\s/g, "")
+    .replace(/(\n)?[^\S\r\n]+\*\/$/, "");
+};
+
 export const replaceModelTypes = (
   sourceFile: SourceFile,
   modelTypes: ModelTypes,
@@ -115,14 +123,6 @@ export const replaceModelTypes = (
         });
       }
     }
-
-    // this strips comments of special tokens since ts-morph generates jsdoc tokens automatically
-    const cleanComment = (comment: string) => {
-      return comment
-        .replace(/^\/\*\*[^\S\r\n]?/, "")
-        .replace(/[^\S\r\n]+\*\s/g, "")
-        .replace(/(\n)?[^\S\r\n]+\*\/$/, "");
-    };
 
     // TODO: this section is almost identical to the virtual property section above, refactor
     if (comments.length > 0) {

--- a/src/helpers/tests/artifacts/user.gen.ts
+++ b/src/helpers/tests/artifacts/user.gen.ts
@@ -45,9 +45,17 @@ _id: mongoose.Types.ObjectId;
 export type User = {
 email: string;
 firstName: string;
+/** inline jsdoc */
 lastName: string;
+/**
+ * single line jsdoc
+ */
 metadata?: any;
 bestFriend?: User["_id"] | User;
+/**
+ * multiline
+ * jsdoc
+ */
 friends: UserFriend[];
 city: {
 coordinates: number[];
@@ -156,9 +164,17 @@ _id: mongoose.Types.ObjectId;
 export type UserDocument = mongoose.Document<mongoose.Types.ObjectId, UserQueries> & UserMethods & {
 email: string;
 firstName: string;
+/** inline jsdoc */
 lastName: string;
+/**
+ * single line jsdoc
+ */
 metadata?: any;
 bestFriend?: UserDocument["_id"] | UserDocument;
+/**
+ * multiline
+ * jsdoc
+ */
 friends: mongoose.Types.DocumentArray<UserFriendDocument>;
 city: {
 coordinates: mongoose.Types.Array<number>;

--- a/src/helpers/tests/artifacts/user.ts
+++ b/src/helpers/tests/artifacts/user.ts
@@ -11,15 +11,23 @@ const UserSchema: UserSchema = new Schema({
     type: String,
     required: true
   },
+  /** inline jsdoc */
   lastName: {
     type: String,
     required: true
   },
+  /**
+   * single line jsdoc
+   */
   metadata: Schema.Types.Mixed,
   bestFriend: {
     type: Schema.Types.ObjectId,
     ref: "User"
   },
+  /**
+   * multiline
+   * jsdoc
+   */
   friends: [
     {
       uid: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Contains information parsed from ts-morph about various types for each model
+ */
+export type ModelTypes = {
+  [modelName: string]: {
+    /** mongoose method function types */
+    methods: { [funcName: string]: string };
+    /** mongoose static function types */
+    statics: { [funcName: string]: string };
+    /** mongoose query function types */
+    query: { [funcName: string]: string };
+    /** mongoose virtual types */
+    virtuals: { [virtualName: string]: string };
+    schemaVariableName?: string;
+    modelVariableName?: string;
+    filePath: string;
+    /** comments found in the mongoose schema */
+    comments: {
+      path: string;
+      comment: string;
+    }[];
+  };
+};


### PR DESCRIPTION
Detects JSDocs in Mongoose schemas and adds them to the generated TS types. Currently this will parse comments up to a depth of 2 levels. If we find that this does not suffice all users then we can add a CLI option to let the user pass a custom value.

~~Tests currently failing due to a Mongoose bug which should be fixed in the next release (6.0.13)~~ 6.0.13 was still missing one small type fix, a PR has been made [here](https://github.com/Automattic/mongoose/pull/11026) to address this. Once this is released, tests will pass on this PR and it can be merged.

Closes https://github.com/francescov1/mongoose-tsgen/issues/13