### PR TITLE
fix: Fix schema keys with special caracters

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -30,7 +30,7 @@ const formatKeyEntry = ({
   let line = "";
 
   if (key) {
-    line += key;
+    line += JSON.stringify(key);
     if (isOptional) line += "?";
     line += ": ";
   }

--- a/src/helpers/tests/parser.test.ts
+++ b/src/helpers/tests/parser.test.ts
@@ -6,45 +6,55 @@ describe("getParseKeyFn", () => {
     // see https://mongoosejs.com/docs/schematypes.html#arrays
     const parseKey = parser.getParseKeyFn(false, false, false);
 
-    expect(parseKey("test1a", { type: [mongoose.Schema.Types.Mixed] })).toBe("test1a: any[];\n");
-    expect(parseKey("test1b", [mongoose.Schema.Types.Mixed])).toBe("test1b: any[];\n");
+    expect(parseKey("test1a", { type: [mongoose.Schema.Types.Mixed] })).toBe("\"test1a\": any[];\n");
+    expect(parseKey("test1b", [mongoose.Schema.Types.Mixed])).toBe("\"test1b\": any[];\n");
 
-    expect(parseKey("test2a", { type: [] })).toBe("test2a: any[];\n");
-    expect(parseKey("test2b", [])).toBe("test2b: any[];\n");
+    expect(parseKey("test2a", { type: [] })).toBe("\"test2a\": any[];\n");
+    expect(parseKey("test2b", [])).toBe("\"test2b\": any[];\n");
 
-    expect(parseKey("test3a", { type: Array })).toBe("test3a: any[];\n");
-    expect(parseKey("test3b", Array)).toBe("test3b: any[];\n");
+    expect(parseKey("test3a", { type: Array })).toBe("\"test3a\": any[];\n");
+    expect(parseKey("test3b", Array)).toBe("\"test3b\": any[];\n");
 
-    expect(parseKey("test4a", { type: [{}] })).toBe("test4a: any[];\n");
-    expect(parseKey("test4b", [{}])).toBe("test4b: any[];\n");
+    expect(parseKey("test4a", { type: [{}] })).toBe("\"test4a\": any[];\n");
+    expect(parseKey("test4b", [{}])).toBe("\"test4b\": any[];\n");
   });
 
   test("handles Object equivalents as `any`", () => {
     // see https://mongoosejs.com/docs/schematypes.html#mixed
     const parseKey = parser.getParseKeyFn(false, false, false);
 
-    expect(parseKey("test1a", { type: mongoose.Schema.Types.Mixed })).toBe("test1a?: any;\n");
-    expect(parseKey("test1b", mongoose.Schema.Types.Mixed)).toBe("test1b?: any;\n");
+    expect(parseKey("test1a", { type: mongoose.Schema.Types.Mixed })).toBe("\"test1a\"?: any;\n");
+    expect(parseKey("test1b", mongoose.Schema.Types.Mixed)).toBe("\"test1b\"?: any;\n");
     expect(parseKey("test1c", { type: mongoose.Schema.Types.Mixed, required: true })).toBe(
-      "test1c: any;\n"
+      "\"test1c\": any;\n"
     );
 
-    expect(parseKey("test2a", { type: {} })).toBe("test2a?: any;\n");
-    expect(parseKey("test2b", {})).toBe("test2b?: any;\n");
-    expect(parseKey("test2c", { type: {}, required: true })).toBe("test2c: any;\n");
+    expect(parseKey("test2a", { type: {} })).toBe("\"test2a\"?: any;\n");
+    expect(parseKey("test2b", {})).toBe("\"test2b\"?: any;\n");
+    expect(parseKey("test2c", { type: {}, required: true })).toBe("\"test2c\": any;\n");
 
-    expect(parseKey("test3a", { type: Object })).toBe("test3a?: any;\n");
-    expect(parseKey("test3b", Object)).toBe("test3b?: any;\n");
-    expect(parseKey("test3c", { type: Object, required: true })).toBe("test3c: any;\n");
+    expect(parseKey("test3a", { type: Object })).toBe("\"test3a\"?: any;\n");
+    expect(parseKey("test3b", Object)).toBe("\"test3b\"?: any;\n");
+    expect(parseKey("test3c", { type: Object, required: true })).toBe("\"test3c\": any;\n");
   });
 
   test("handles 2dsphere index edge case", () => {
     const parseKey = parser.getParseKeyFn(false, false, false);
 
     // should be optional; not required like normal arrays
-    expect(parseKey("test1a", { type: [Number], index: "2dsphere" })).toBe("test1a?: number[];\n");
+    expect(parseKey("test1a", { type: [Number], index: "2dsphere" })).toBe("\"test1a\"?: number[];\n");
     // should be required, as usual
-    expect(parseKey("test2a", { type: [Number] })).toBe("test2a: number[];\n");
+    expect(parseKey("test2a", { type: [Number] })).toBe("\"test2a\": number[];\n");
+  });
+
+  test("handles special characters", () => {
+    const parseKey = parser.getParseKeyFn(false, false, false);
+
+    expect(parseKey("test-1a", { type: mongoose.Schema.Types.Mixed })).toBe("\"test-1a\"?: any;\n");
+    expect(parseKey("test_1a", { type: mongoose.Schema.Types.Mixed })).toBe("\"test_1a\"?: any;\n");
+    expect(parseKey("test 1a", { type: mongoose.Schema.Types.Mixed })).toBe("\"test 1a\"?: any;\n");
+    expect(parseKey("test 1a @", { type: mongoose.Schema.Types.Mixed })).toBe("\"test 1a @\"?: any;\n");
+    expect(parseKey("test 1a \"@", { type: mongoose.Schema.Types.Mixed })).toBe("\"test 1a \\\"@\"?: any;\n");
   });
 });
 


### PR DESCRIPTION
Some schema keys could be problematic if they had non JS object characters
    
For example:

```js
{
'foo-bar': {type: String}
}

```

would be resolved into

```js
{
foo-bar?: string;
}

```

instead of

```js
{
'foo-bar'?: string;
}
```

This PR fixes this problem.

Added some tests

But "generator.test.ts" is failing. 
I think it is due to the fact that the output files are not expected to have " characters, but it seems something trivial to change. Let me know first if this PR is ok