### PR TITLE
feat: expose generateDefinitions method as api

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=false

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ All CLI options can be provided using a `mtgen.config.json` file. Use the `--con
 }
 ```
 
+## Use as a module
+
+`mongoose-tsgen` can also be imported or required and used programmatically. Below is an example:
+
+```typescript
+import MongooseTsgen from "mongoose-tsgen";
+
+const tsgen = new MongooseTsgen([]);
+const result = await tsgen.generateDefinitions({
+  flags: {
+    "dry-run": false,
+    "no-format": false,
+    "no-mongoose": false,
+    "no-populate-overload": false,
+    debug: false,
+    output: "./src/interfaces",
+    project: "./"
+  },
+  args: {}
+});
+await result.sourceFile.save();
+```
+
+Note that this will not load the config file.
+
 ## Query Population
 
 Any field with a `ref` property will be typed as `RefDocument["_id"] | RefDocument`. As part of the generated file, mongoose will be augmented with `Query.populate` overloads to narrow return types of populated queries (this can be disabled using the `--no-populate-overload` flag). A helper type `PopulatedDocument` and a type guard function `IsPopulated` will also be generated to help with handling populated documents, see usage below:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Args, Command, Flags, ux } from "@oclif/core";
+import { Args, Command, Interfaces, Flags, ux } from "@oclif/core";
 
 import * as parser from "./helpers/parser";
 import * as tsReader from "./helpers/tsReader";
@@ -6,6 +6,24 @@ import * as paths from "./helpers/paths";
 import * as formatter from "./helpers/formatter";
 import * as generator from "./helpers/generator";
 import * as cli from "./helpers/cli";
+import * as types from "./types";
+
+declare namespace MongooseTsgen {
+  export type CliFlagConfig = Interfaces.InferredFlags<typeof MongooseTsgen["flags"]>;
+  export type FlagConfig = types.Normalize<
+    Omit<CliFlagConfig, "config" | "help" | "json" | "output" | "project"> & {
+      output: string;
+      project: string;
+    }
+  >;
+
+  export type ArgConfig = Interfaces.InferredArgs<typeof MongooseTsgen["args"]>;
+
+  export interface Config {
+    flags: FlagConfig;
+    args: ArgConfig;
+  }
+}
 
 class MongooseTsgen extends Command {
   static id = ".";
@@ -65,12 +83,9 @@ class MongooseTsgen extends Command {
   private async getConfig() {
     const { flags: cliFlags, args } = await this.parse(MongooseTsgen);
 
-    type FlagConfig = Omit<typeof cliFlags, "config"> & {
-      output: string;
-      project: string;
-    };
-
-    const configFileFlags: Partial<FlagConfig> = paths.getConfigFromFile(cliFlags.config);
+    const configFileFlags: Partial<MongooseTsgen.FlagConfig> = paths.getConfigFromFile(
+      cliFlags.config
+    );
 
     // remove "config" since its only used to grab the config file
     delete cliFlags.config;
@@ -84,7 +99,7 @@ class MongooseTsgen extends Command {
       flags: {
         ...configFileFlags,
         ...cliFlags
-      } as FlagConfig,
+      } as MongooseTsgen.FlagConfig,
       args
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Args, Command, Interfaces, Flags, ux } from "@oclif/core";
+import { Args, Command, Config, Interfaces, Flags, ux } from "@oclif/core";
 
 import * as parser from "./helpers/parser";
 import * as tsReader from "./helpers/tsReader";
@@ -17,7 +17,7 @@ declare namespace MongooseTsgen {
     }
   >;
 
-  export type ArgConfig = Interfaces.InferredArgs<typeof MongooseTsgen["args"]>;
+  export type ArgConfig = types.Normalize<Interfaces.InferredArgs<typeof MongooseTsgen["args"]>>;
 
   export interface Config {
     flags: FlagConfig;
@@ -79,6 +79,10 @@ class MongooseTsgen extends Command {
   static args = {
     model_path: Args.string()
   };
+
+  constructor(argv: string[], config = new Config({ root: __dirname })) {
+    super(argv, config);
+  }
 
   private async getConfig() {
     const { flags: cliFlags, args } = await this.parse(MongooseTsgen);

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,11 @@ export type ModelTypes = {
     }[];
   };
 };
+
+type UndefinedKeys<T> = {
+  [K in keyof T]: undefined extends T[K] ? K : never;
+}[keyof T];
+type MarkOptional<T, K extends keyof T = UndefinedKeys<T>> =
+  Omit<T, K> & Partial<Pick<T, K>>;
+type Resolve<T> = { [K in keyof T]: T[K] } & {};
+export type Normalize<T> = Resolve<MarkOptional<T>>;


### PR DESCRIPTION
I would like to use mongoose-tsgen from within another script, and so, I'd like to expose a method that performs the same actions the cli would. I called the method `generateDefinitions`, although we can bikeshed on the name.

Also, if this change is desired, I can update the readme to document this feature.

I've also added some complex typings to infer the parameters type from the oclif configuration, and I think I could upstream that (although, we would need to upgrade to the latest oclif, as it looks like they've deprecated the package youre using).