### PR TITLE
Add support for nested models folder

### DIFF
--- a/src/helpers/paths.ts
+++ b/src/helpers/paths.ts
@@ -30,7 +30,7 @@ export const getModelsPaths = (basePath?: string): string[] => {
     const { ext } = path.parse(basePath);
 
     // if path points to a folder, search for ts files in folder.
-    const modelsFolderPath = ext === "" ? path.join(basePath, "*.ts") : basePath;
+    const modelsFolderPath = ext === "" ? path.join(basePath, "**/*.ts") : basePath;
 
     modelsPaths = glob.sync(modelsFolderPath, {
       ignore: "**/node_modules/**"


### PR DESCRIPTION
In this short PR we added support for nested models folders. This would allow models inside a structure like this, to be recognized:

```
models/
    | subfolder1
        | model1.ts
    |subfolder2
        | model2.ts
    |model3.ts
```