### PR TITLE
feat: support mongoose-autopopulate

### DIFF
--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -505,9 +505,10 @@ export const getParseKeyFn = (
         docRef = getSubDocName(docRef);
       }
 
-      valType = isDocument ?
-        `${docRef}Document["_id"] | ${docRef}Document` :
-        `${docRef}["_id"] | ${docRef}`;
+      const populatedType = isDocument ? `${docRef}Document` : docRef;
+      valType = val.autopopulate ? // support for mongoose-autopopulate
+        populatedType :
+        `${populatedType}["_id"] | ${populatedType}`;
     } else {
       // _ids are always required
       if (key === "_id") isOptional = false;

--- a/src/helpers/tests/parser.test.ts
+++ b/src/helpers/tests/parser.test.ts
@@ -60,6 +60,28 @@ describe("getParseKeyFn", () => {
     expect(parseKey("test2c", mongoose.Schema.Types.Date)).toBe("test2c?: Date;\n");
     expect(parseKey("test2d", mongoose.Schema.Types.Boolean)).toBe("test2d?: boolean;\n");
   });
+
+  test("handles references and mongoose-autopopulate", () => {
+    const parseKey = parser.getParseKeyFn(false, false, false);
+
+    expect(parseKey("test1a", { type: mongoose.Schema.Types.ObjectId, ref: "RefTest" })).toBe(
+      'test1a?: RefTest["_id"] | RefTest;\n'
+    );
+    expect(
+      parseKey("test1b", {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "RefTest",
+        autopopulate: false
+      })
+    ).toBe('test1b?: RefTest["_id"] | RefTest;\n');
+    expect(
+      parseKey("test1c", {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "RefTest",
+        autopopulate: true
+      })
+    ).toBe("test1c?: RefTest;\n");
+  });
 });
 
 describe("convertToSingular", () => {


### PR DESCRIPTION
There is a package called [mongoose-autopopulate](https://www.npmjs.com/package/mongoose-autopopulate) which allows annotating the fields of a schema and then always populates the selected fields.
We are using this package and it would be great if mongoose-tsgen would support its annotation, and generate typescript definitions accordingly.

In this PR I made a small change that does work for type definition generation, but I am not sure if this is good enough, or something else needs to be done as well.

Additionally, mongoose-autopopulate has some configs, like a per-field maxDepth options (eg.: `{maxDepth: 2}`), which limits the population depth. Im not sure if this is even possible, but it would be even better if mongoose-tsgen could generate type definitions with fields that are populated until some depth :D