### PR TITLE
Allow nested generics in model initializer

### DIFF
--- a/src/helpers/tsReader.ts
+++ b/src/helpers/tsReader.ts
@@ -261,8 +261,8 @@ const parseModelInitializer = (
 
   // if model is a named import, we can match this without `mongoose.` prefix
   const pattern = isModelNamedImport ?
-    /model(?:<\w+,\w+(?:,\w+)?>)?\(["'`](\w+)["'`],(\w+),?\)/ :
-    /mongoose\.model(?:<\w+,\w+(?:,\w+)?>)?\(["'`](\w+)["'`],(\w+),?\)/;
+    /model(?:<.+?>)?\(["'`](\w+)["'`],(\w+),?\)/ :
+    /mongoose\.model(?:<.+?>)?\(["'`](\w+)["'`],(\w+),?\)/;
   const modelInitMatch = callExprStr.match(pattern);
   if (!modelInitMatch) {
     if (process.env.DEBUG) {


### PR DESCRIPTION
I was having trouble using nested generics in the model initializer:

Here's a slightly contrived example:
```ts
import { Schema, model } from 'mongoose';
import type { TestDocument, TestModel } from '../interfaces/models.gen';

const TestSchema = new Schema({
  test: {
    type: String,
    default: 'hello',
    required: true,
  },
});

TestSchema.methods = {
  isActive() {
    return true;
  },
};

type SomeGenericType<T = {}> = TestDocument & T;

// The problem occurs here because the generic params for model don't match the regex defined in tsReader.ts
export const Test = model<SomeGenericType<{}>, TestModel>('Test', TestSchema);
```

This causes the generation of TestMethods to default to `(this: TestDocument, ...args: any[]) => any`, rather than its true type.

Before fix:
```ts
export type TestMethods = {
  isActive: (this: TestDocument, ...args: any[]) => any;
};
```

After fix:
```ts
export type TestMethods = {
  isActive: (this: TestDocument) => boolean;
};
```

# Fix

This PR fixes it by adjusting the regex to allow (& ignore) anything in the generic params for the model initializer.