### PR TITLE
fix: resolve path aliases being extended from base configs

### DIFF
--- a/src/helpers/tests/tsReader.test.ts
+++ b/src/helpers/tests/tsReader.test.ts
@@ -1,14 +1,10 @@
-import fs from "fs";
-import path from "path";
 import { parseTSConfig } from "../tsReader";
 
 describe("parseTSConfig", () => {
   test("path aliases should be resolved from extended tsconfig.json", () => {
     const testTsConfigPath = "tsconfig.test.json";
 
-    const tsConfigString = fs.readFileSync(testTsConfigPath, "utf8");
-
-    const tsConfig = parseTSConfig(tsConfigString, path.dirname(testTsConfigPath));
+    const tsConfig = parseTSConfig(testTsConfigPath);
 
     // Check of extended path is present
     expect(tsConfig.compilerOptions.paths["@package-lock-json"][0]).toBe("./package-lock.json");

--- a/src/helpers/tests/tsReader.test.ts
+++ b/src/helpers/tests/tsReader.test.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+import { parseTSConfig } from "../tsReader";
+
+describe("parseTSConfig", () => {
+  test("path aliases should be resolved from extended tsconfig.json", () => {
+    const testTsConfigPath = "tsconfig.test.json";
+
+    const tsConfigString = fs.readFileSync(testTsConfigPath, "utf8");
+
+    const tsConfig = parseTSConfig(tsConfigString, path.dirname(testTsConfigPath));
+
+    // Check of extended path is present
+    expect(tsConfig.compilerOptions.paths["@package-lock-json"][0]).toBe("./package-lock.json");
+    // Check if extended path is present and overridden
+    expect(tsConfig.compilerOptions.paths["@package-json"][0]).toBe("./package.json");
+  });
+});

--- a/src/helpers/tsReader.ts
+++ b/src/helpers/tsReader.ts
@@ -383,9 +383,8 @@ export const registerUserTs = (basePath: string): (() => void) | null => {
   });
 
   // handle path aliases
-  const tsConfigString = fs.readFileSync(foundPath, "utf8");
   try {
-    const tsConfig = parseTSConfig(tsConfigString, path.dirname(foundPath));
+    const tsConfig = parseTSConfig(foundPath);
     if (tsConfig?.compilerOptions?.paths) {
       const baseUrl = process.cwd();
       if (process.env.DEBUG) {
@@ -409,18 +408,17 @@ export const registerUserTs = (basePath: string): (() => void) | null => {
   }
 };
 
-export function parseTSConfig(tsConfigString: string, basePath: string) {
+export function parseTSConfig(tsconfigFilePath: string) {
+  const tsConfigString = fs.readFileSync(tsconfigFilePath, "utf8");
+
   const tsConfig = JSON.parse(stripJsonComments(tsConfigString));
 
   // Handle the case where the tsconfig.json file has a "extends" property
   if (tsConfig.extends) {
     // Resolve the path to the extended tsconfig.json file
-    const extendedPath = path.resolve(basePath, tsConfig.extends);
+    const extendedPath = path.resolve(path.dirname(tsconfigFilePath), tsConfig.extends);
     // Read and merge paths from the extended tsconfig.json recursively
-    const extendedConfig = parseTSConfig(
-      fs.readFileSync(extendedPath, "utf8"),
-      path.dirname(extendedPath)
-    );
+    const extendedConfig = parseTSConfig(extendedPath);
     // Merge paths from extendedConfig into tsConfig
     tsConfig.compilerOptions.paths = {
       ...extendedConfig.compilerOptions.paths,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@package-lock-json": ["./package-lock.json"],
+      "@package-json": ["./fake.package.json"]
+    }
+  }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
     "importHelpers": true,
@@ -9,7 +10,10 @@
     "target": "es2017",
     "esModuleInterop": true,
     "types": ["node", "jest"],
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "paths": {
+      "@package-json": ["./package.json"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Hey there! I'm using this great package in my NX monorepo project, but I'm encountering an issue with resolving relative imports through path aliases. Currently, paths are only taken from the nearest or specified `tsconfig` file, which disrupts the generation process in my application.

This pull request enhances how paths are fetched. It will now recursively collect paths from extended configurations and update them with the latest paths up to the nearest or specified tsconfig.