### PR TITLE
Fix unable to find module of absolute path imports due to tsconfig's `baseUrl` not being read

### DIFF
--- a/src/helpers/tests/paths.test.ts
+++ b/src/helpers/tests/paths.test.ts
@@ -60,7 +60,7 @@ describe("getModelsPaths", () => {
 describe("cleanOutputPath", () => {
   test("path ending in custom file name", () => {
     const cleaned = paths.cleanOutputPath("/test/path/with/index.d.ts");
-    expect(cleaned).toBe("/test/path/with/index.d.ts");
+    expect(cleaned).toBe(path.normalize("/test/path/with/index.d.ts"));
   });
 
   test("path ending in javascript file extension error", () => {

--- a/src/helpers/tsReader.ts
+++ b/src/helpers/tsReader.ts
@@ -386,7 +386,7 @@ export const registerUserTs = (basePath: string): (() => void) | null => {
   try {
     const tsConfig = parseTSConfig(foundPath);
     if (tsConfig?.compilerOptions?.paths) {
-      const baseUrl = process.cwd();
+      const baseUrl = path.join(process.cwd(), tsConfig?.compilerOptions?.baseUrl ?? "");
       if (process.env.DEBUG) {
         console.log(
           "tsreader: Found paths field in tsconfig.json, registering project with tsconfig-paths using baseUrl " +


### PR DESCRIPTION
I was having trouble of not being able to generate the types due to using absolute path imports with `baseUrl` in the `tsconfig.json`.

![image](https://github.com/francescov1/mongoose-tsgen/assets/48067039/9fcc8545-cc0b-430a-87c3-30831640f4ff)

Upon checking, apparently, the ts-parser does not read the `baseUrl` from the `tsconfig.json`, which causes the resolved path to be wrong