### PR TITLE
Add base url to parseTSConfig

### DIFF
--- a/src/helpers/tests/tsReader.test.ts
+++ b/src/helpers/tests/tsReader.test.ts
@@ -1,14 +1,18 @@
 import { parseTSConfig } from "../tsReader";
 
 describe("parseTSConfig", () => {
-  test("path aliases should be resolved from extended tsconfig.json", () => {
+  test("path aliases and baseUrl should be resolved from extended tsconfig.json", () => {
     const testTsConfigPath = "tsconfig.test.json";
 
     const tsConfig = parseTSConfig(testTsConfigPath);
 
     // Check of extended path is present
     expect(tsConfig.compilerOptions.paths["@package-lock-json"][0]).toBe("./package-lock.json");
+    
     // Check if extended path is present and overridden
     expect(tsConfig.compilerOptions.paths["@package-json"][0]).toBe("./package.json");
+
+    // Ensure the parent's base URL is overridden by the child's
+    expect(tsConfig.compilerOptions.baseUrl).toBe("./a-base-url-from-child");
   });
 });

--- a/src/helpers/tsReader.ts
+++ b/src/helpers/tsReader.ts
@@ -424,6 +424,12 @@ export function parseTSConfig(tsconfigFilePath: string) {
       ...extendedConfig.compilerOptions.paths,
       ...tsConfig.compilerOptions.paths
     };
+
+    // We only want to set the base URL if its not already set, since the child tsconfig should always overwrite extended tsconfigs. 
+    // So the first child we find with a base URL be the final base URL
+    if (extendedConfig.compilerOptions.baseUrl && !tsConfig.compilerOptions.baseUrl) {
+      tsConfig.compilerOptions.baseUrl = extendedConfig.compilerOptions.baseUrl
+    }
   }
 
   return tsConfig;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./a-base-url",
     "paths": {
       "@package-lock-json": ["./package-lock.json"],
       "@package-json": ["./fake.package.json"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "types": ["node", "jest"],
     "typeRoots": ["./node_modules/@types"],
+    "baseUrl": "./a-base-url-from-child",
     "paths": {
       "@package-json": ["./package.json"]
     }


### PR DESCRIPTION
This PR adds recursive baseUrl capturing to parseTSConfig so that we capture baseUrls from extended tsconfigs.