### PR TITLE
use tsreader for nomongoose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongoose-tsgen",
-  "version": "9.5.2",
+  "version": "9.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongoose-tsgen",
-      "version": "9.5.2",
+      "version": "9.5.3",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-tsgen",
   "description": "A Typescript interface generator for Mongoose that works out of the box.",
-  "version": "9.5.2",
+  "version": "9.5.3",
   "author": "Francesco Virga @francescov1",
   "bin": {
     "mtgen": "./bin/run"

--- a/src/helpers/tsReader.ts
+++ b/src/helpers/tsReader.ts
@@ -224,7 +224,12 @@ function findTypesInFile(sourceFile: SourceFile, modelTypes: TsReaderModelTypes)
 
       const stringLiteral = callExpr2?.getArguments()[0];
       const propAccessExpr2 = callExpr2?.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
-      if (propAccessExpr2?.getName() !== "virtual") continue;
+      if (propAccessExpr2?.getName() !== "virtual") {
+        if (process.env.DEBUG) {
+          console.warn("tsreader: virtual found on schema does not have virtual initializer");
+        }
+        continue;
+      }
 
       const virtualName = stringLiteral?.getText();
       let returnType = type?.split("=> ")?.[1];
@@ -241,7 +246,15 @@ function findTypesInFile(sourceFile: SourceFile, modelTypes: TsReaderModelTypes)
        * @experimental trying this out since certain virtual types are indeterminable and get set to void, which creates incorrect TS errors
        * This should be a fine workaround because virtual properties shouldn't return solely `void`, they return real values.
        */
-      if (returnType === "void") returnType = "any";
+      if (returnType === "void") {
+        if (process.env.DEBUG) {
+          console.warn(
+            "tsreader: return type found as void, this usually means we couldn't determine the type"
+          );
+        }
+
+        returnType = "any";
+      }
       const virtualNameSanitized = virtualName.slice(1, virtualName.length - 1);
 
       modelTypes[modelName].virtuals[virtualNameSanitized] = returnType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,14 +148,14 @@ class MongooseTsgen extends Command {
       datesAsStrings
     });
 
+    const modelTypes = tsReader.getModelTypes(modelsPaths);
+    const models = loadModels(modelsPaths);
+    generator.replaceModelTypes(sourceFile, modelTypes, models);
+
     // only get model types (methods, statics, queries & virtuals) if user does not specify `noMongoose`,
     if (noMongoose) {
       this.log("Skipping TS model parsing and sourceFile model type replacement");
     } else {
-      const modelTypes = tsReader.getModelTypes(modelsPaths);
-      const models = loadModels(modelsPaths);
-      generator.replaceModelTypes(sourceFile, modelTypes, models);
-
       // add populate helpers
       await generator.addPopulateHelpers(sourceFile);
       // add mongoose.Query.populate overloads

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -402,14 +402,18 @@ export const getTypeFromKeyValue = ({
     let docRef = val.ref.replace?.(`'`, "");
 
     if (typeof val.ref === "function") {
-      // If we get a function, we cant determine the document that we would populate, so just assume it's an ObjectId
-      valueType = "mongoose.Types.ObjectId";
+      if (noMongoose) {
+        valueType = "string";
+      } else {
+        // If we get a function, we cant determine the document that we would populate, so just assume it's an ObjectId
+        valueType = "mongoose.Types.ObjectId";
 
-      // If generating the document version, we can also provide document as an option to reflect the populated case. But for
-      // lean docs we can't do this cause we don't have a base type to extend from (since we can't determine it when parsing only JS).
-      // Later the tsReader can implement a function typechecker to subtitute the type with the more exact one.
-      if (isDocument) {
-        valueType += " | mongoose.Document";
+        // If generating the document version, we can also provide document as an option to reflect the populated case. But for
+        // lean docs we can't do this cause we don't have a base type to extend from (since we can't determine it when parsing only JS).
+        // Later the tsReader can implement a function typechecker to subtitute the type with the more exact one.
+        if (isDocument) {
+          valueType += " | mongoose.Document";
+        }
       }
     } else if (docRef) {
       // If val.ref is an invalid type (not a string) then this gets skipped.


### PR DESCRIPTION
Fixes #173 and a small bug where function refs are typed as ObjectId instead of strings for `--no-mongoose` flag